### PR TITLE
Allow dynamically link against libpcap

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -10,7 +10,7 @@ import (
 )
 
 /*
-#cgo LDFLAGS: -L/usr/local/lib -lpcap -static
+#cgo LDFLAGS: -L/usr/local/lib -lpcap
 #include <stdlib.h>
 #include <pcap.h>
 */

--- a/compile_static.go
+++ b/compile_static.go
@@ -1,0 +1,12 @@
+// +build static !dynamic
+
+package elibpcap
+
+
+/*
+#cgo LDFLAGS: -L/usr/local/lib -lpcap -static
+#include <stdlib.h>
+#include <pcap.h>
+*/
+import "C"
+


### PR DESCRIPTION

* `go build` -> static link
* `go build -tags dynamic` -> dynamically link

Context: https://github.com/mozillazg/ptcpdump/issues/258