### PR TITLE
Reduce unnecessary stack consuming 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ Projects that use elibpcap:
 - [eCapture](https://github.com/gojue/ecapture)
 - [ptcpdump](https://github.com/mozillazg/ptcpdump)
 - [skbdist](https://github.com/Asphaltt/skbdist)
+- [bpfsnoop](https://github.com/bpfsnoop/bpfsnoop)

--- a/compile.go
+++ b/compile.go
@@ -27,7 +27,7 @@ const (
 type StackOffset int
 
 const (
-	BpfReadKernelOffset StackOffset = -8*(iota+1) - 80
+	BpfReadKernelOffset StackOffset = -8 * (iota + 1)
 	R1Offset
 	R2Offset
 	R3Offset


### PR DESCRIPTION
Because the stub subprog uses its own stack memory, the **80** bytes are unnecessary to be reserved.